### PR TITLE
Fix container check

### DIFF
--- a/scripts/spotify
+++ b/scripts/spotify
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if docker inspect -f "{{ .Name }}" spotify | grep -q '/spotify'; then
+if [[ -n "$(docker ps -qaf 'name=spotify')" ]]; then
 	docker restart spotify
 else
 	USER_UID=$(id -u)


### PR DESCRIPTION
The previous check failed if the image was named spotify and there were
no containers launched. Which caused the docker inspect return info
about the image instead of the containers, this is why the .Name didn't
work.

Instead of relying on this behavior we can instead explicitly do a
`docker ps` with a filter on the `name`.

This solves: #8