### PR TITLE
Fix X display permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,3 @@ Run Spotify inside an isolated [Docker](http://www.docker.io) container. This is
   ```
 
 4. Use Spotify.
-
-## Troubleshooting
-
-Q: After running scripts/spotify I get:
-
-  ```
-  (spotify:29): Gtk-WARNING **: cannot open display: unix:0
-  ```
-
-A: You need to allow connections to the X server:
-
-  ```sh
-  xhost +
-  ```

--- a/scripts/spotify
+++ b/scripts/spotify
@@ -6,6 +6,7 @@ if [[ -n "$(docker ps -qaf 'name=spotify')" ]]; then
 else
 	USER_UID=$(id -u)
 	USER_GID=$(id -g)
+	xhost +local:docker
 
 	docker run --rm \
 		--env=USER_UID=$USER_UID \


### PR DESCRIPTION
Instead of running something like `xhost +` which is kind of bad since
it would allow any connection from anywhere access to your X Server you
can instead run `xhost +local:docker` which will only allow the docker
network locally.

Any other solution is welcome if you know the X Server stuff better.