### PR TITLE
Link dbus into container for mpris support

### DIFF
--- a/scripts/spotify
+++ b/scripts/spotify
@@ -8,6 +8,10 @@ else
 	USER_GID=$(id -g)
 	xhost "si:localuser:${USER}"
 
+	[[ ${DBUS_SESSION_BUS_ADDRESS} =~ 'unix:path'\
+		 && -S ${DBUS_SESSION_BUS_ADDRESS#*=} ]]\
+		 && DBUS=${DBUS_SESSION_BUS_ADDRESS#*=}
+
 	docker run --rm --name spotify \
 		-e "USER_UID=${USER_UID}" \
 		-e "USER_GID=${USER_GID}" \
@@ -16,6 +20,8 @@ else
 		-v "/run/user/${USER_UID}/pulse:/run/pulse:ro" \
 		-v "${HOME}/.spotify/config:/data/config" \
 		-v "${HOME}/.spotify/cache:/data/cache" \
+		${DBUS:+-v "${DBUS}:/run/dbus"} \
+		${DBUS:+-e "DBUS_SESSION_BUS_ADDRESS=/run/dbus"} \
 		--device /dev/dri \
 		spotify
 fi


### PR DESCRIPTION
Linking the DBUS session into the container allows Spotify to connect to it and send/receive updates from it. This also takes care of media player controls (#13) as long as the desktop environment supports it.