### PR TITLE
Updated Spotify repo public key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Terje Larsen
 
 # Install Spotify and PulseAudio.
 WORKDIR /usr/src
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0DF731E45CE24F27EEEB1450EFDC8610341D9410 \
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 931FF8E79F0876134EDDBDCCA87FF9DF48BF1C90 \
 	&& echo deb http://repository.spotify.com stable non-free > /etc/apt/sources.list.d/spotify.list \
 	&& apt-get update \
 	&& apt-get install -y \


### PR DESCRIPTION
They've updated the repo public key: https://www.spotify.com/se/download/linux/